### PR TITLE
use embedded-hal::digital::v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ readme = "README.md"
 [dependencies]
 byteorder = { version = "1", default-features = false }
 
+[dependencies.void]
+default-features = false
+version = "1.0.2"
+
 [dependencies.embedded-hal]
 features = ["unproven"]
 version = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ pub mod ds18b20;
 pub use ds18b20::DS18B20;
 
 use hal::blocking::delay::DelayUs;
-use hal::digital::InputPin;
-use hal::digital::OutputPin;
+use hal::digital::v2::InputPin;
+use hal::digital::v2::OutputPin;
 
 pub const ADDRESS_BYTES: u8 = 8;
 pub const ADDRESS_BITS: u8 = ADDRESS_BYTES * 8;
@@ -166,8 +166,8 @@ impl DeviceSearch {
     }
 }
 
-pub trait OpenDrainOutput: OutputPin + InputPin {}
-impl<P: OutputPin + InputPin> OpenDrainOutput for P {}
+pub trait OpenDrainOutput: OutputPin<Error = void::Void> + InputPin<Error = void::Void> {}
+impl<P: OutputPin<Error = void::Void> + InputPin<Error = void::Void>> OpenDrainOutput for P {}
 
 pub struct OneWire<'a> {
     output: &'a mut OpenDrainOutput,
@@ -438,7 +438,7 @@ impl<'a> OneWire<'a> {
     }
 
     fn set_input(&mut self) {
-        self.output.set_high()
+        self.output.set_high();
     }
 
     fn set_output(&mut self) {
@@ -446,15 +446,16 @@ impl<'a> OneWire<'a> {
     }
 
     fn write_low(&mut self) {
-        self.output.set_low()
+        self.output.set_low();
     }
 
     fn write_high(&mut self) {
-        self.output.set_high()
+        self.output.set_high();
     }
 
     fn read(&self) -> bool {
-        self.output.is_high()
+        // is_low in stm32f1xx-hal return Ok only, so unwrap looks safe
+        self.output.is_high().unwrap()
     }
 }
 


### PR DESCRIPTION
Hello.

I try use last stm32f1xx-hal (along as onewire) in my project and found errors:
```
error[E0277]: the trait bound `heat_control_f103::gpiob::PBx<heat_control_f103::Output<heat_control_f103::stm32f1xx_hal::gpio::OpenDrain>>: heat_control_f103::_embedded_hal_digital_OutputPin` is not satisfied
   --> src/main.rs:249:33
    |
249 |     let mut wire = OneWire::new(&mut one, false);
    |                                 ^^^^^^^^ the trait `heat_control_f103::_embedded_hal_digital_OutputPin` is not implemented for `heat_control_f103::gpiob::PBx<heat_control_f103::Output<heat_control_f103::stm32f1xx_hal::gpio::OpenDrain>>`
    |
    = note: required because of the requirements on the impl of `onewire::OpenDrainOutput` for `heat_control_f103::gpiob::PBx<heat_control_f103::Output<heat_control_f103::stm32f1xx_hal::gpio::OpenDrain>>`
    = note: required for the cast to the object type `dyn onewire::OpenDrainOutput`

error[E0277]: the trait bound `heat_control_f103::gpiob::PBx<heat_control_f103::Output<heat_control_f103::stm32f1xx_hal::gpio::OpenDrain>>: heat_control_f103::_embedded_hal_digital_InputPin` is not satisfied
   --> src/main.rs:249:33
    |
249 |     let mut wire = OneWire::new(&mut one, false);
    |                                 ^^^^^^^^ the trait `heat_control_f103::_embedded_hal_digital_InputPin` is not implemented for `heat_control_f103::gpiob::PBx<heat_control_f103::Output<heat_control_f103::stm32f1xx_hal::gpio::OpenDrain>>`
    |
    = note: required because of the requirements on the impl of `onewire::OpenDrainOutput` for `heat_control_f103::gpiob::PBx<heat_control_f103::Output<heat_control_f103::stm32f1xx_hal::gpio::OpenDrain>>`
    = note: required for the cast to the object type `dyn onewire::OpenDrainOutput`
```

Using  embedded_hal::digital::v2 solves this problem, so what you say about this PR?

unwrap() in method read() at line 458 looks ugly, but I don't found better solution.. Any ideas?