### PR TITLE
lib: Remove duplicate select in reset_select_{write,read}_only

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,6 @@ impl<E: core::fmt::Debug, ODO: OpenDrainOutput<Error = E>> OneWire<ODO> {
     ) -> Result<(), Error<E>> {
         self.reset(delay)?;
         self.select(delay, device)?;
-        self.select(delay, device)?;
         self.read_bytes(delay, read)?;
         Ok(())
     }
@@ -302,7 +301,6 @@ impl<E: core::fmt::Debug, ODO: OpenDrainOutput<Error = E>> OneWire<ODO> {
         write: &[u8],
     ) -> Result<(), Error<E>> {
         self.reset(delay)?;
-        self.select(delay, device)?;
         self.select(delay, device)?;
         self.write_bytes(delay, write)?;
         Ok(())


### PR DESCRIPTION
Using these functions would send the select rom command as data after the actual select rom command corrupting any actual data that was supposed to be read/written.