### PR TITLE
CRC error: expected is 255 but computed 201

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -593,8 +593,7 @@ impl<E: core::fmt::Debug, ODO: OpenDrainOutput<Error = E>> OneWire<ODO> {
 
     fn disable_parasite_mode(&mut self) -> Result<(), E> {
         // let cli = DisableInterrupts::new();
-        self.set_input()?;
-        self.write_low()
+        self.set_input()
     }
 
     fn set_input(&mut self) -> Result<(), E> {


### PR DESCRIPTION
Hi!
I had problems reading temperatures when I tried to use more than ~7 sensors ds18b20 on the same bus (CRC error saying that expected crc is 255 but computed 201).
I noticed that data line stays low between calling `ds18b20.measure_temperature(&mut wire, &mut delay)` and `ds18b20.read_temperature(&mut wire, &mut delay)`.
After applying this patch, I was able to communicate with 14 sensors.